### PR TITLE
Add NorgAI-specific Privacy Policy for AppSource certification

### DIFF
--- a/docs/legal/norgai-privacy.html
+++ b/docs/legal/norgai-privacy.html
@@ -385,7 +385,7 @@
                                         </tr>
                                         <tr>
                                             <td>Passwords</td>
-                                            <td>Never stored by NorgAI</td>
+                                            <td>Never stored by us</td>
                                             <td>&mdash;</td>
                                         </tr>
                                     </tbody>

--- a/docs/legal/norgai-privacy.html
+++ b/docs/legal/norgai-privacy.html
@@ -1,0 +1,621 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <meta name="description" content="Privacy Policy for NorgAI, the AI presentation add-in for Microsoft PowerPoint by Inscripta AI — what data we collect, how we store it, retention, AI processing and your rights." />
+        <meta name="author" content="Team Inscripta" />
+        <title>NorgAI Privacy Policy | Inscripta AI</title>
+        <!-- Canonical-->
+        <link rel="canonical" href="https://inscripta.ai/legal/norgai-privacy" />
+        <!-- Favicon-->
+        <link rel="icon" type="image/x-icon" href="/assets/favicon.png" />
+        <!--Font-->
+        <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css?family=Nunito Sans:400,700" rel="stylesheet" />
+        <!-- Core theme CSS (includes Bootstrap)-->
+        <link href="/css/styles.min.css" rel="stylesheet" />
+        <!-- Font Awesome icons-->
+        <link href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" rel="stylesheet" />
+        <style>
+            .pp-lead {
+                font-size: 1.05rem;
+            }
+            .pp-section {
+                scroll-margin-top: 90px;
+                margin-top: 3.25rem;
+            }
+            .pp-section > h2 {
+                padding-bottom: 0.4rem;
+                border-bottom: 2px solid #f0f2f8;
+                font-size: 1.6rem;
+            }
+            .pp-section h3 {
+                margin-top: 1.75rem;
+                font-size: 1.2rem;
+            }
+            .pp-toc {
+                background: #f5f7ff;
+                border: 1px solid #e6eaf6;
+                border-radius: 12px;
+                padding: 1.25rem 1.5rem;
+            }
+            .pp-toc h2 {
+                font-size: 1.1rem;
+                margin-bottom: 0.75rem;
+                color: #192b80;
+                border: 0;
+                padding: 0;
+            }
+            .pp-toc ul {
+                margin: 0;
+                padding-left: 0;
+                list-style: none;
+                columns: 2;
+                column-gap: 2rem;
+            }
+            .pp-toc li {
+                margin-bottom: 0.35rem;
+                break-inside: avoid;
+            }
+            .pp-toc a {
+                color: #192b80;
+                text-decoration: none;
+            }
+            .pp-toc a:hover {
+                text-decoration: underline;
+            }
+            .pp-glance {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+                gap: 1rem;
+                margin: 1.75rem 0 0.5rem;
+            }
+            .pp-card {
+                background: #fff;
+                border: 1px solid #e6eaf6;
+                border-radius: 12px;
+                padding: 1.1rem 1.25rem;
+                box-shadow: 0 8px 24px rgba(25, 43, 128, 0.06);
+            }
+            .pp-card .pp-ic {
+                width: 38px;
+                height: 38px;
+                border-radius: 10px;
+                background: #eef1ff;
+                color: #192b80;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-size: 1rem;
+                margin-bottom: 0.6rem;
+            }
+            .pp-card h4 {
+                font-size: 1rem;
+                font-weight: 700;
+                margin: 0 0 0.25rem;
+                color: #1a1a1a;
+            }
+            .pp-card p {
+                font-size: 0.875rem;
+                color: #5b6172;
+                margin: 0;
+            }
+            .pp-table th {
+                background: #f5f7ff;
+                white-space: nowrap;
+            }
+            .pp-table td,
+            .pp-table th {
+                vertical-align: top;
+            }
+            .pp-note {
+                border-left: 4px solid #192b80;
+                background: #f5f7ff;
+                padding: 0.85rem 1.1rem;
+                border-radius: 0 8px 8px 0;
+                margin: 1.25rem 0;
+            }
+            .pp-note p {
+                margin: 0;
+            }
+            .pp-updated {
+                color: #6c757d;
+                font-size: 0.95rem;
+            }
+            .pp-cta {
+                margin-top: 3.5rem;
+                padding-top: 2rem;
+                border-top: 1px solid #eaecf3;
+            }
+            @media (max-width: 575px) {
+                .pp-toc ul {
+                    columns: 1;
+                }
+            }
+        </style>
+        <!-- Google Tag Manager-->
+        <script>
+            (function (w, d, s, l, i) {
+                w[l] = w[l] || [];
+                w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+                var f = d.getElementsByTagName(s)[0],
+                    j = d.createElement(s),
+                    dl = l != 'dataLayer' ? '&l=' + l : '';
+                j.async = true;
+                j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+                f.parentNode.insertBefore(j, f);
+            })(window, document, 'script', 'dataLayer', 'GTM-5XQVFGS');
+        </script>
+        <!-- End Google Tag Manager-->
+    </head>
+    <body id="page-top">
+        <!-- Google Tag Manager (noscript)-->
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XQVFGS" height="0" width="0" style="display: none; visibility: hidden"></iframe></noscript>
+        <!-- End Google Tag Manager (noscript)-->
+        <!-- Navigation-->
+        <nav class="navbar navbar-expand-lg navbar-light fixed-top py-3" id="mainNav">
+            <div class="container px-4 px-lg-5"><a class="navbar-brand" href="/"></a></div>
+        </nav>
+        <!-- Producthead-->
+        <header class="simplehead">
+            <div class="container px-4 px-lg-5 h-100">
+                <div class="row gx-4 gx-lg-5 h-100">
+                    <div class="col-lg-9 align-self-end"><h1 class="text-white font-weight-bold">NorgAI Privacy Policy</h1></div>
+                    <div class="col-lg-9 align-self-baseline mt-3"><p class="text-white mb-0">How NorgAI, the AI presentation add-in for Microsoft PowerPoint, collects, uses, stores and protects your data</p></div>
+                </div>
+            </div>
+        </header>
+        <section class="page-section" id="about">
+            <div class="container px-4 px-lg-5">
+                <div class="row gx-4 gx-lg-5 justify-content-center">
+                    <div class="col-lg-10">
+                        <p class="pp-updated">Last Updated: 17 June 2026 &nbsp;&middot;&nbsp; Effective Date: 17 June 2026</p>
+                        <p class="mt-3 pp-lead">
+                            This Privacy Policy explains how
+                            <strong>Inscripta AI Technologies Private Limited</strong>
+                            (&ldquo;Inscripta AI&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo; or &ldquo;our&rdquo;) collects, uses, stores, shares and protects personal data and customer content in connection with
+                            <strong>NorgAI</strong>
+                            , our artificial-intelligence add-in for Microsoft PowerPoint, together with its related task-pane application and cloud services (collectively, the &ldquo;Service&rdquo;). It applies specifically to the NorgAI Service and its users.
+                        </p>
+                        <p>
+                            This Privacy Policy supplements, and should be read together with, the
+                            <a class="text-primary" href="/legal/norgai-terms">NorgAI Terms of Use</a>
+                            . For the privacy practices of our general marketing website, see our
+                            <a class="text-primary" href="/legal/privacy">website Privacy Policy</a>
+                            . Where you and Inscripta AI have entered into a separate signed agreement or data-processing addendum for the Service, that agreement governs to the extent of any conflict.
+                        </p>
+                        <!-- At a glance-->
+                        <div class="pp-glance">
+                            <div class="pp-card">
+                                <div class="pp-ic"><i class="fas fa-folder"></i></div>
+                                <h4>Your documents stay yours</h4>
+                                <p>You retain ownership of everything you upload. Content is scoped to your project and never shared across organisations.</p>
+                            </div>
+                            <div class="pp-card">
+                                <div class="pp-ic"><i class="fas fa-brain"></i></div>
+                                <h4>No training on your data</h4>
+                                <p>We do not use your documents or AI output to train or improve foundation models for other customers.</p>
+                            </div>
+                            <div class="pp-card">
+                                <div class="pp-ic"><i class="fas fa-trash-alt"></i></div>
+                                <h4>Delete anytime</h4>
+                                <p>Uploaded documents and AI knowledge are retained until you delete them, and removed after account termination.</p>
+                            </div>
+                            <div class="pp-card">
+                                <div class="pp-ic"><i class="fas fa-shield-alt"></i></div>
+                                <h4>Encrypted &amp; access-controlled</h4>
+                                <p>Data is encrypted in transit (TLS 1.2+) and at rest, with access limited to members of your project.</p>
+                            </div>
+                        </div>
+                        <!-- TOC-->
+                        <div class="pp-toc mt-4">
+                            <h2>Contents</h2>
+                            <ul>
+                                <li><a href="#scope">1. Scope &amp; Who We Are</a></li>
+                                <li><a href="#collect">2. Information We Collect</a></li>
+                                <li><a href="#use">3. How We Use Your Information</a></li>
+                                <li><a href="#legal-basis">4. Legal Bases for Processing</a></li>
+                                <li><a href="#storage">5. Storage, Location &amp; Security</a></li>
+                                <li><a href="#retention">6. Data Retention &amp; Deletion</a></li>
+                                <li><a href="#ai">7. AI Processing &amp; Model Training</a></li>
+                                <li><a href="#sharing">8. Sharing &amp; Sub-processors</a></li>
+                                <li><a href="#transfers">9. International Data Transfers</a></li>
+                                <li><a href="#rights">10. Your Privacy Rights</a></li>
+                                <li><a href="#children">11. Children&rsquo;s Privacy</a></li>
+                                <li><a href="#cookies">12. Cookies &amp; Local Storage</a></li>
+                                <li><a href="#breach">13. Data Breach Notification</a></li>
+                                <li><a href="#changes">14. Changes to This Policy</a></li>
+                                <li><a href="#contact">15. Contact Us</a></li>
+                            </ul>
+                        </div>
+                        <!-- 1-->
+                        <div class="pp-section" id="scope">
+                            <h2>1. Scope &amp; Who We Are</h2>
+                            <p>Inscripta AI Technologies Private Limited is the controller responsible for personal data processed through the NorgAI Service. Where you use the Service as part of your organisation&rsquo;s subscription, your organisation is the controller of the customer content you upload, and Inscripta AI acts as a processor on your organisation&rsquo;s behalf in respect of that content.</p>
+                            <p>NorgAI is a task-pane add-in that runs inside Microsoft PowerPoint. It reads reference documents you upload into a project and uses generative-AI and large language models to help you generate, adapt and modify presentations. This Policy covers the Service&rsquo;s task-pane application, backend cloud services and supporting infrastructure.</p>
+                        </div>
+                        <!-- 2-->
+                        <div class="pp-section" id="collect">
+                            <h2>2. Information We Collect</h2>
+                            <p>We collect the following categories of data when you use the Service:</p>
+                            <div class="table-responsive">
+                                <table class="table table-bordered pp-table">
+                                    <thead>
+                                        <tr>
+                                            <th scope="col">Category</th>
+                                            <th scope="col">Examples</th>
+                                            <th scope="col">Source</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Identity data</td>
+                                            <td>Name, email address, user ID</td>
+                                            <td>Your identity provider at sign-in</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Authentication data</td>
+                                            <td>Access tokens, session state, cached OIDC claims</td>
+                                            <td>Generated during sign-in (no passwords)</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Document content</td>
+                                            <td>Documents you upload and the content of your open presentation</td>
+                                            <td>Uploaded or opened by you</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Conversation data</td>
+                                            <td>Chat messages, retrieval queries, AI responses</td>
+                                            <td>Generated as you use the Service</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Usage data</td>
+                                            <td>API calls, document uploads, query and token counts</td>
+                                            <td>Collected automatically</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Device &amp; technical data</td>
+                                            <td>IP address, browser type, operating system</td>
+                                            <td>Collected automatically</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <p>We do not collect your password &mdash; authentication is handled by your identity provider using OAuth 2.0 / OpenID Connect. You should not upload documents containing special categories of sensitive personal data unless you have a lawful basis and any required data-processing terms are in place.</p>
+                        </div>
+                        <!-- 3-->
+                        <div class="pp-section" id="use">
+                            <h2>3. How We Use Your Information</h2>
+                            <p>We use the data described above to:</p>
+                            <ul>
+                                <li>provide, operate and maintain the Service, including generating, adapting and modifying presentations from your documents;</li>
+                                <li>authenticate you and secure your account and sessions;</li>
+                                <li>store and retrieve your uploaded documents and AI knowledge, scoped to your project;</li>
+                                <li>respond to your requests and provide customer support;</li>
+                                <li>monitor usage, detect and prevent fraud, abuse and security incidents, and enforce our Terms; and</li>
+                                <li>meet our legal, regulatory and contractual obligations.</li>
+                            </ul>
+                            <p>We do not use your document content or AI output for advertising, and we do not sell your personal data.</p>
+                        </div>
+                        <!-- 4-->
+                        <div class="pp-section" id="legal-basis">
+                            <h2>4. Legal Bases for Processing</h2>
+                            <p>Where data-protection law &mdash; such as the EU/UK General Data Protection Regulation (GDPR) or India&rsquo;s Digital Personal Data Protection Act, 2023 (DPDP Act) &mdash; applies, we rely on the following legal bases: performance of a contract (to provide the Service to you or your organisation); our legitimate interests (to secure, operate and improve the Service, balanced against your rights); compliance with a legal obligation; and consent, where specifically requested. Where Inscripta AI acts as a processor (or, under the DPDP Act, a Data Processor) it processes data on the documented instructions of your organisation as controller (Data Fiduciary).</p>
+                        </div>
+                        <!-- 5-->
+                        <div class="pp-section" id="storage">
+                            <h2>5. Storage, Location &amp; Security</h2>
+                            <p>
+                                Customer content and account data are hosted on cloud infrastructure operated by our infrastructure provider,
+                                <strong>E2E Networks</strong>
+                                , located in
+                                <strong>India</strong>
+                                . We apply appropriate technical and organisational measures to protect your data, including:
+                            </p>
+                            <ul>
+                                <li>
+                                    encryption of data in transit using
+                                    <strong>TLS 1.2 or higher</strong>
+                                    , and encryption of data at rest;
+                                </li>
+                                <li>authentication via OAuth 2.0 / OpenID Connect, with no password storage;</li>
+                                <li>access scoped to members of the relevant project, so document content is not shared across organisations;</li>
+                                <li>role-based access controls, secrets management, and audit logging of access to customer data; and</li>
+                                <li>network and application security controls, vulnerability management and monitoring.</li>
+                            </ul>
+                            <div class="table-responsive mt-3">
+                                <table class="table table-bordered pp-table">
+                                    <thead>
+                                        <tr>
+                                            <th scope="col">Store</th>
+                                            <th scope="col">What it holds</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Document database</td>
+                                            <td>User identity, document metadata, AI conversation logs, usage metrics, audit events (with anonymised IP and hashed user-agent) and cached OIDC claims</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Vector database</td>
+                                            <td>Document text chunks and vector embeddings used for retrieval</td>
+                                        </tr>
+                                        <tr>
+                                            <td>In-memory store</td>
+                                            <td>Hashed authentication state tokens, token blacklists and session data</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                        <!-- 6-->
+                        <div class="pp-section" id="retention">
+                            <h2>6. Data Retention &amp; Deletion</h2>
+                            <p>We retain data only for as long as needed to provide the Service and to meet our legal obligations. Retention by data type:</p>
+                            <div class="table-responsive">
+                                <table class="table table-bordered pp-table">
+                                    <thead>
+                                        <tr>
+                                            <th scope="col">Data type</th>
+                                            <th scope="col">Storage</th>
+                                            <th scope="col">Retention</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Uploaded documents</td>
+                                            <td>Stored securely, scoped to your project</td>
+                                            <td>Until you delete them</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Open presentation content</td>
+                                            <td>Sent for processing during an operation</td>
+                                            <td>Not stored after the operation completes</td>
+                                        </tr>
+                                        <tr>
+                                            <td>AI knowledge entries</td>
+                                            <td>Stored per-user and per-project</td>
+                                            <td>Until you delete them</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Authentication tokens</td>
+                                            <td>Stored in your browser&rsquo;s local storage</td>
+                                            <td>Until session expiry or logout</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Passwords</td>
+                                            <td>Never stored by NorgAI</td>
+                                            <td>&mdash;</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <p>
+                                You can delete your uploaded documents and AI knowledge at any time from within the Service. Following account termination, we delete or de-identify the associated customer data within
+                                <strong>30 days</strong>
+                                , unless a longer period is required by law. Backup copies are purged on our standard backup-rotation cycle.
+                            </p>
+                        </div>
+                        <!-- 7-->
+                        <div class="pp-section" id="ai">
+                            <h2>7. AI Processing &amp; Model Training</h2>
+                            <p>NorgAI uses generative-AI and large language models, including models operated by third-party model providers engaged as sub-processors, to generate output from your documents. NorgAI&rsquo;s memory and knowledge features are designed to leverage your organisation&rsquo;s own institutional knowledge to improve output for you, within your own account and projects.</p>
+                            <div class="pp-note">
+                                <p>
+                                    <strong>We do not use your documents or AI output to train, fine-tune or improve foundation models for the benefit of other customers, and we do not share your documents or output with other customers.</strong>
+                                    We may use aggregated and de-identified information that does not identify you or any individual to operate, secure and improve the Service.
+                                </p>
+                            </div>
+                            <p>Output is generated automatically, may be inaccurate or incomplete, and should be reviewed before use. NorgAI proposes a plan for your review and approval before applying changes, and the Service does not make automated decisions producing legal or similarly significant effects about individuals.</p>
+                        </div>
+                        <!-- 8-->
+                        <div class="pp-section" id="sharing">
+                            <h2>8. Sharing &amp; Sub-processors</h2>
+                            <p>We do not sell, rent or trade your personal data or document content. We share data only as follows:</p>
+                            <ul>
+                                <li>
+                                    <strong>Sub-processors</strong>
+                                    who process data on our behalf to provide the Service &mdash; including our cloud-infrastructure provider and large-language-model providers &mdash; under contractual confidentiality and data-protection obligations;
+                                </li>
+                                <li>
+                                    <strong>within your organisation</strong>
+                                    , with members of the relevant project;
+                                </li>
+                                <li>
+                                    <strong>where required by law</strong>
+                                    , or to protect the rights, safety and security of users, the public or Inscripta AI; and
+                                </li>
+                                <li>
+                                    <strong>in connection with a corporate transaction</strong>
+                                    such as a merger, acquisition or sale of assets, subject to this Policy.
+                                </li>
+                            </ul>
+                            <p>
+                                Where required, we enter into data-sharing agreements or data-processing addenda with sub-processors and with customers. A current list of sub-processors is available on request at
+                                <a class="text-primary" href="mailto:norgai.support@inscripta.ai">norgai.support@inscripta.ai</a>
+                                .
+                            </p>
+                            <p>NorgAI runs as an add-in inside Microsoft PowerPoint and is distributed through Microsoft AppSource. Your use of Microsoft PowerPoint, Microsoft 365 and Microsoft AppSource is governed by Microsoft&rsquo;s own terms and privacy statement, for which Inscripta AI is not responsible.</p>
+                        </div>
+                        <!-- 9-->
+                        <div class="pp-section" id="transfers">
+                            <h2>9. International Data Transfers</h2>
+                            <p>Your data is primarily stored and processed in India. Where data is transferred to, or accessed from, a country other than the one in which you are located &mdash; for example by a sub-processor &mdash; we put in place appropriate safeguards required by applicable data-protection law, such as standard contractual clauses, to protect your data.</p>
+                        </div>
+                        <!-- 10-->
+                        <div class="pp-section" id="rights">
+                            <h2>10. Your Privacy Rights</h2>
+                            <p>Subject to applicable law, you have the right to:</p>
+                            <ul>
+                                <li>
+                                    <strong>access</strong>
+                                    the personal data we hold about you;
+                                </li>
+                                <li>
+                                    <strong>correct or update</strong>
+                                    inaccurate or incomplete personal data;
+                                </li>
+                                <li>
+                                    <strong>delete</strong>
+                                    your personal data;
+                                </li>
+                                <li>
+                                    <strong>restrict or object to</strong>
+                                    our processing of your personal data;
+                                </li>
+                                <li>
+                                    <strong>data portability</strong>
+                                    &mdash; receive your data in a portable format; and
+                                </li>
+                                <li>
+                                    <strong>withdraw consent</strong>
+                                    at any time, where processing is based on consent.
+                                </li>
+                            </ul>
+                            <p>
+                                To exercise these rights, contact us at
+                                <a class="text-primary" href="mailto:norgai.support@inscripta.ai">norgai.support@inscripta.ai</a>
+                                . We will respond within the timeframe required by applicable law. Where you use the Service under your organisation&rsquo;s subscription, you may need to direct certain requests to your organisation as the controller, and we will assist them in responding. You also have the right to lodge a complaint with your local data-protection authority.
+                            </p>
+                            <p>
+                                <strong>Region-specific rights.</strong>
+                                If you are in the EEA or UK, you have the rights described above under the GDPR. If you are in India, you may exercise your rights under the DPDP Act, including by contacting our Grievance Officer (see &ldquo;Contact Us&rdquo; below). If you are a California resident, you may have rights under the CCPA/CPRA, including the right to know, delete and correct your personal information, and the right not to be discriminated against for exercising those rights; we do not sell or share personal information as those terms are defined under the CCPA/CPRA.
+                            </p>
+                        </div>
+                        <!-- 11-->
+                        <div class="pp-section" id="children">
+                            <h2>11. Children&rsquo;s Privacy</h2>
+                            <p>
+                                The Service is intended for business use by individuals who are at least
+                                <strong>18 years of age</strong>
+                                . We do not knowingly collect personal data from children or minors. If you believe a minor has provided us with personal data, please contact us so we can delete it.
+                            </p>
+                        </div>
+                        <!-- 12-->
+                        <div class="pp-section" id="cookies">
+                            <h2>12. Cookies &amp; Local Storage</h2>
+                            <p>
+                                The NorgAI task-pane stores authentication tokens in your browser&rsquo;s local storage to keep you signed in; these persist until session expiry or logout. We and our analytics providers may use cookies and similar technologies to operate and improve the Service. For cookies used on our marketing website, see our
+                                <a class="text-primary" href="/legal/privacy">website Privacy Policy</a>
+                                .
+                            </p>
+                        </div>
+                        <!-- 13-->
+                        <div class="pp-section" id="breach">
+                            <h2>13. Data Breach Notification</h2>
+                            <p>
+                                We maintain a documented security incident-response process. In the event of a personal-data breach that is likely to result in a risk to affected individuals, we will notify the relevant supervisory authority and affected individuals (or, where Inscripta AI is a processor, the controller) without undue delay and, where feasible,
+                                <strong>within 72 hours</strong>
+                                of becoming aware of it, in accordance with applicable law.
+                            </p>
+                        </div>
+                        <!-- 14-->
+                        <div class="pp-section" id="changes">
+                            <h2>14. Changes to This Policy</h2>
+                            <p>We may update this Privacy Policy from time to time to reflect changes to the Service or to legal requirements. For material changes we will update the &ldquo;Last Updated&rdquo; date above and, where appropriate, provide additional notice. Your continued use of the Service after changes take effect constitutes acceptance of the revised Policy.</p>
+                        </div>
+                        <!-- 15-->
+                        <div class="pp-section" id="contact">
+                            <h2>15. Contact Us</h2>
+                            <p>For questions about this Privacy Policy, or to exercise your privacy rights, contact Inscripta AI Technologies Private Limited at:</p>
+                            <ul>
+                                <li>
+                                    Privacy &amp; support:
+                                    <a class="text-primary" href="mailto:norgai.support@inscripta.ai">norgai.support@inscripta.ai</a>
+                                </li>
+                                <li>
+                                    General &amp; legal notices:
+                                    <a class="text-primary" href="mailto:sales@inscripta.ai">sales@inscripta.ai</a>
+                                </li>
+                            </ul>
+                            <p>
+                                <strong>Grievance Officer (India).</strong>
+                                In accordance with India&rsquo;s Digital Personal Data Protection Act, 2023 and applicable IT rules, our Grievance Officer can be reached at
+                                <a class="text-primary" href="mailto:norgai.support@inscripta.ai">norgai.support@inscripta.ai</a>
+                                . We aim to acknowledge and address grievances within the timeframe prescribed by applicable law.
+                            </p>
+                        </div>
+                        <div class="pp-cta">
+                            <a class="btn btn-secondary mt-2" href="/legal/norgai-terms">
+                                <i class="fas fa-arrow-left me-2"></i>
+                                Read the NorgAI Terms of Use
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <!-- Footer-->
+        <!-- Footer-->
+        <footer class="bg-dark py-5 text-white" role="contentinfo">
+            <div class="container px-4 px-lg-5">
+                <div class="row">
+                    <!-- Left section: Logo and description-->
+                    <div class="col-lg-4 mb-4 mb-lg-0">
+                        <img class="img-logo mb-3" src="/assets/img/logo/logo-cs.png" alt="Inscripta AI Logo" />
+                        <p class="small text-light mb-3">Inscripta delivers AI solutions through both innovative products and expert consulting. Our offerings include ParseQa QABot for high-accuracy question answering and ParseQa Curate for intelligent content organization, alongside scalable capabilities in Generative AI, Agentic Workflows, LLMs, NLP, OCR, and Document AI. Whether through Saas applications, ready-to-deploy tools or customized engagements, we help enterprises streamline knowledge workflows, and accelerate AI adoption with measurable impact.</p>
+                        <div class="mb-2">
+                            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="100 100 540 540"><path d="M112 128C85.5 128 64 149.5 64 176C64 191.1 71.1 205.3 83.2 214.4L291.2 370.4C308.3 383.2 331.7 383.2 348.8 370.4L556.8 214.4C568.9 205.3 576 191.1 576 176C576 149.5 554.5 128 528 128L112 128zM64 260L64 448C64 483.3 92.7 512 128 512L512 512C547.3 512 576 483.3 576 448L576 260L377.6 408.8C343.5 434.4 296.5 434.4 262.4 408.8L64 260z"></path></svg>
+                            <a class="text-info text-decoration-none" href="mailto:sales@inscripta.ai">sales@inscripta.ai</a>
+                        </div>
+                        <div class="mb-2">
+                            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="100 100 540 540"><path d="M512 96L127.9 96C110.3 96 96 110.5 96 128.3L96 511.7C96 529.5 110.3 544 127.9 544L512 544C529.6 544 544     529.5 544 511.7L544 128.3C544 110.5 529.6 96 512 96zM231.4 480L165 480L165 266.2L231.5 266.2L231.5 480L231.4 480zM198.2 160C219.5 160 236.7 177.2 236.7 198.5C236.7 219.8 219.5 237 198.2 237C176.9 237 159.7 219.8 159.7 198.5C159.7 177.2 176.9 160 198.2 160zM480.3 480L413.9 480L413.9 376C413.9 351.2 413.4 319.3 379.4 319.3C344.8 319.3 339.5 346.3 339.5 374.2L339.5 480L273.1 480L273.1 266.2L336.8 266.2L336.8 295.4L337.7 295.4C346.6 278.6 368.3 260.9 400.6 260.9C467.8 260.9 480.3 305.2 480.3 362.8L480.3 480z"></path></svg>
+                            <a class="text-info text-decoration-none align-items-center" href="https://www.linkedin.com/company/inscripta-ai/" target="_blank">LinkedIn</a>
+                        </div>
+                    </div>
+                    <!-- Right sections: Products, Resources, Contact-->
+                    <div class="col-lg-7 offset-lg-1">
+                        <div class="row">
+                            <div class="col-md-3 mb-4 mb-md-0">
+                                <p class="text-white mb-3">Products</p>
+                                <ul class="list-unstyled">
+                                    <li><a class="text-light" href="/products/parseqa/qabot">ParseQa QABot</a></li>
+                                    <li><a class="text-light" href="/products/parseqa/curate">ParseQa Curate</a></li>
+                                    <li><a class="text-light" href="/products/norgai">NorgAI</a></li>
+                                </ul>
+                            </div>
+                            <div class="col-md-3 mb-4 mb-md-0">
+                                <p class="text-white mb-3">Resources</p>
+                                <ul class="list-unstyled">
+                                    <li><a class="text-light" href="https://blog.inscripta.ai">Blogs</a></li>
+                                </ul>
+                            </div>
+                            <div class="col-md-3 mb-4 mb-md-0">
+                                <p class="text-white bold mb-3">Services</p>
+                                <ul class="list-unstyled">
+                                    <li><a class="text-light" href="/consulting">Consulting</a></li>
+                                </ul>
+                            </div>
+                            <div class="col-md-3 mb-4 mb-md-0">
+                                <p class="text-white mb-3">Contact</p>
+                                <ul class="list-unstyled">
+                                    <li><a class="text-light" href="mailto:sales@inscripta.ai">Email Us</a></li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row mt-4">
+                    <div class="col-12 text-center">
+                        <div class="small text-light mt-2">
+                            &copy; 2026 Inscripta AI. All Rights Reserved.
+                            <a class="text-light mx-2">Terms of Service</a>
+                            <a class="text-light mx-2" href="/legal/privacy">Privacy Policy</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </footer>
+        <!-- Bootstrap core JS-->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js"></script>
+        <!-- Core theme JS-->
+        <script src="/js/scripts.js"></script>
+        <!-- For loading images lazily-->
+        <script src="/js/lazysizes.min.js"></script>
+        <script src="/js/ls.unveilhooks.min.js"></script>
+        <link rel="stylesheet" href="https://website-bot.inscripta.ai/static/style.css" />
+        <!-- Load the chatbot bundle and auto-open-->
+        <script src="https://website-bot.inscripta.ai/static/chatbot.bundle.iife.js" onload="window.chatbotApp.openChat()"></script>
+    </body>
+</html>

--- a/docs/products/norgai.html
+++ b/docs/products/norgai.html
@@ -926,7 +926,7 @@
                     <div class="mt-3">
                         <a class="small text-muted mx-2" href="/legal/norgai-terms">NorgAI Terms of Use</a>
                         <span class="small text-muted">&middot;</span>
-                        <a class="small text-muted mx-2" href="/legal/privacy">Privacy Policy</a>
+                        <a class="small text-muted mx-2" href="/legal/norgai-privacy">Privacy Policy</a>
                     </div>
                 </div>
             </div>

--- a/docs/products/norgai/quick-start.html
+++ b/docs/products/norgai/quick-start.html
@@ -577,7 +577,7 @@
                                     </tr>
                                     <tr>
                                         <td>Privacy policy</td>
-                                        <td><a class="text-primary" href="/legal/privacy">inscripta.ai/legal/privacy</a></td>
+                                        <td><a class="text-primary" href="/legal/norgai-privacy">inscripta.ai/legal/norgai-privacy</a></td>
                                     </tr>
                                     <tr>
                                         <td>Terms of use</td>

--- a/docs/products/norgai/user-guide.html
+++ b/docs/products/norgai/user-guide.html
@@ -1152,7 +1152,7 @@
                             </ul>
                             <p>
                                 Full privacy policy:
-                                <a class="text-primary" href="/legal/privacy">inscripta.ai/legal/privacy</a>
+                                <a class="text-primary" href="/legal/norgai-privacy">inscripta.ai/legal/norgai-privacy</a>
                             </p>
                         </div>
                         <!-- 17. Support & Contact-->
@@ -1179,7 +1179,7 @@
                                         </tr>
                                         <tr>
                                             <td>Privacy policy</td>
-                                            <td><a class="text-primary" href="/legal/privacy">inscripta.ai/legal/privacy</a></td>
+                                            <td><a class="text-primary" href="/legal/norgai-privacy">inscripta.ai/legal/norgai-privacy</a></td>
                                         </tr>
                                         <tr>
                                             <td>Terms of use</td>

--- a/src/pug/legal/norgai-privacy.pug
+++ b/src/pug/legal/norgai-privacy.pug
@@ -249,7 +249,7 @@ html(lang='en')
                                             td Until session expiry or logout
                                         tr
                                             td Passwords
-                                            td Never stored by NorgAI
+                                            td Never stored by us
                                             td &mdash;
                             p You can delete your uploaded documents and AI knowledge at any time from within the Service. Following account termination, we delete or de-identify the associated customer data within #[strong 30 days], unless a longer period is required by law. Backup copies are purged on our standard backup-rotation cycle.
 

--- a/src/pug/legal/norgai-privacy.pug
+++ b/src/pug/legal/norgai-privacy.pug
@@ -1,0 +1,330 @@
+doctype html
+html(lang='en')
+
+    head
+
+        meta(charset='utf-8')
+        meta(name='viewport', content='width=device-width, initial-scale=1, shrink-to-fit=no')
+        meta(name='description', content='Privacy Policy for NorgAI, the AI presentation add-in for Microsoft PowerPoint by Inscripta AI — what data we collect, how we store it, retention, AI processing and your rights.')
+        meta(name='author', content='Team Inscripta')
+
+        title NorgAI Privacy Policy | Inscripta AI
+
+        // Canonical
+        link(rel='canonical', href='https://inscripta.ai/legal/norgai-privacy')
+
+        // Favicon
+        link(rel='icon', type='image/x-icon', href='/assets/favicon.png')
+
+        //Font
+        link(href='https://fonts.googleapis.com/css?family=Lato:400,700', rel='stylesheet')
+        link(href='https://fonts.googleapis.com/css?family=Nunito Sans:400,700', rel='stylesheet')
+
+        // Core theme CSS (includes Bootstrap)
+        link(href='/css/styles.min.css', rel='stylesheet')
+
+        // Font Awesome icons
+        link(href='https://use.fontawesome.com/releases/v5.3.1/css/all.css', rel='stylesheet')
+
+        style.
+          .pp-lead { font-size: 1.05rem; }
+          .pp-section { scroll-margin-top: 90px; margin-top: 3.25rem; }
+          .pp-section > h2 { padding-bottom: .4rem; border-bottom: 2px solid #f0f2f8; font-size: 1.6rem; }
+          .pp-section h3 { margin-top: 1.75rem; font-size: 1.2rem; }
+          .pp-toc { background: #f5f7ff; border: 1px solid #e6eaf6; border-radius: 12px; padding: 1.25rem 1.5rem; }
+          .pp-toc h2 { font-size: 1.1rem; margin-bottom: .75rem; color: #192B80; border: 0; padding: 0; }
+          .pp-toc ul { margin: 0; padding-left: 0; list-style: none; columns: 2; column-gap: 2rem; }
+          .pp-toc li { margin-bottom: .35rem; break-inside: avoid; }
+          .pp-toc a { color: #192B80; text-decoration: none; }
+          .pp-toc a:hover { text-decoration: underline; }
+          .pp-glance { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin: 1.75rem 0 .5rem; }
+          .pp-card { background: #fff; border: 1px solid #e6eaf6; border-radius: 12px; padding: 1.1rem 1.25rem; box-shadow: 0 8px 24px rgba(25, 43, 128, .06); }
+          .pp-card .pp-ic { width: 38px; height: 38px; border-radius: 10px; background: #eef1ff; color: #192B80; display: flex; align-items: center; justify-content: center; font-size: 1rem; margin-bottom: .6rem; }
+          .pp-card h4 { font-size: 1rem; font-weight: 700; margin: 0 0 .25rem; color: #1a1a1a; }
+          .pp-card p { font-size: .875rem; color: #5b6172; margin: 0; }
+          .pp-table th { background: #f5f7ff; white-space: nowrap; }
+          .pp-table td, .pp-table th { vertical-align: top; }
+          .pp-note { border-left: 4px solid #192B80; background: #f5f7ff; padding: .85rem 1.1rem; border-radius: 0 8px 8px 0; margin: 1.25rem 0; }
+          .pp-note p { margin: 0; }
+          .pp-updated { color: #6c757d; font-size: .95rem; }
+          .pp-cta { margin-top: 3.5rem; padding-top: 2rem; border-top: 1px solid #eaecf3; }
+          @media (max-width: 575px) { .pp-toc ul { columns: 1; } }
+
+        // Google Tag Manager
+        script.
+          (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+          new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+          })(window,document,'script','dataLayer','GTM-5XQVFGS');
+        // End Google Tag Manager
+
+
+    body#page-top
+        // Google Tag Manager (noscript)
+        noscript
+            iframe(src='https://www.googletagmanager.com/ns.html?id=GTM-5XQVFGS' height='0' width='0' style='display:none;visibility:hidden')
+        // End Google Tag Manager (noscript)
+
+
+        // Navigation
+        nav#mainNav.navbar.navbar-expand-lg.navbar-light.fixed-top.py-3
+            .container.px-4.px-lg-5
+                a.navbar-brand(href='/')
+
+        // Producthead
+        header.simplehead
+            .container.px-4.px-lg-5.h-100
+                .row.gx-4.gx-lg-5.h-100
+                    .col-lg-9.align-self-end
+                        h1.text-white.font-weight-bold NorgAI Privacy Policy
+                    .col-lg-9.align-self-baseline.mt-3
+                        p.text-white.mb-0 How NorgAI, the AI presentation add-in for Microsoft PowerPoint, collects, uses, stores and protects your data
+
+        section#about.page-section
+            .container.px-4.px-lg-5
+                .row.gx-4.gx-lg-5.justify-content-center
+                    .col-lg-10
+                        p.pp-updated Last Updated: 17 June 2026 &nbsp;&middot;&nbsp; Effective Date: 17 June 2026
+
+                        p.mt-3.pp-lead This Privacy Policy explains how #[strong Inscripta AI Technologies Private Limited] (&ldquo;Inscripta AI&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo; or &ldquo;our&rdquo;) collects, uses, stores, shares and protects personal data and customer content in connection with #[strong NorgAI], our artificial-intelligence add-in for Microsoft PowerPoint, together with its related task-pane application and cloud services (collectively, the &ldquo;Service&rdquo;). It applies specifically to the NorgAI Service and its users.
+
+                        p This Privacy Policy supplements, and should be read together with, the #[a.text-primary(href='/legal/norgai-terms') NorgAI Terms of Use]. For the privacy practices of our general marketing website, see our #[a.text-primary(href='/legal/privacy') website Privacy Policy]. Where you and Inscripta AI have entered into a separate signed agreement or data-processing addendum for the Service, that agreement governs to the extent of any conflict.
+
+                        // At a glance
+                        .pp-glance
+                            .pp-card
+                                .pp-ic: i.fas.fa-folder
+                                h4 Your documents stay yours
+                                p You retain ownership of everything you upload. Content is scoped to your project and never shared across organisations.
+                            .pp-card
+                                .pp-ic: i.fas.fa-brain
+                                h4 No training on your data
+                                p We do not use your documents or AI output to train or improve foundation models for other customers.
+                            .pp-card
+                                .pp-ic: i.fas.fa-trash-alt
+                                h4 Delete anytime
+                                p Uploaded documents and AI knowledge are retained until you delete them, and removed after account termination.
+                            .pp-card
+                                .pp-ic: i.fas.fa-shield-alt
+                                h4 Encrypted &amp; access-controlled
+                                p Data is encrypted in transit (TLS 1.2+) and at rest, with access limited to members of your project.
+
+                        // TOC
+                        .pp-toc.mt-4
+                            h2 Contents
+                            ul
+                                li: a(href='#scope') 1. Scope &amp; Who We Are
+                                li: a(href='#collect') 2. Information We Collect
+                                li: a(href='#use') 3. How We Use Your Information
+                                li: a(href='#legal-basis') 4. Legal Bases for Processing
+                                li: a(href='#storage') 5. Storage, Location &amp; Security
+                                li: a(href='#retention') 6. Data Retention &amp; Deletion
+                                li: a(href='#ai') 7. AI Processing &amp; Model Training
+                                li: a(href='#sharing') 8. Sharing &amp; Sub-processors
+                                li: a(href='#transfers') 9. International Data Transfers
+                                li: a(href='#rights') 10. Your Privacy Rights
+                                li: a(href='#children') 11. Children&rsquo;s Privacy
+                                li: a(href='#cookies') 12. Cookies &amp; Local Storage
+                                li: a(href='#breach') 13. Data Breach Notification
+                                li: a(href='#changes') 14. Changes to This Policy
+                                li: a(href='#contact') 15. Contact Us
+
+                        // 1
+                        .pp-section#scope
+                            h2 1. Scope &amp; Who We Are
+                            p Inscripta AI Technologies Private Limited is the controller responsible for personal data processed through the NorgAI Service. Where you use the Service as part of your organisation&rsquo;s subscription, your organisation is the controller of the customer content you upload, and Inscripta AI acts as a processor on your organisation&rsquo;s behalf in respect of that content.
+                            p NorgAI is a task-pane add-in that runs inside Microsoft PowerPoint. It reads reference documents you upload into a project and uses generative-AI and large language models to help you generate, adapt and modify presentations. This Policy covers the Service&rsquo;s task-pane application, backend cloud services and supporting infrastructure.
+
+                        // 2
+                        .pp-section#collect
+                            h2 2. Information We Collect
+                            p We collect the following categories of data when you use the Service:
+                            .table-responsive
+                                table.table.table-bordered.pp-table
+                                    thead
+                                        tr
+                                            th(scope='col') Category
+                                            th(scope='col') Examples
+                                            th(scope='col') Source
+                                    tbody
+                                        tr
+                                            td Identity data
+                                            td Name, email address, user ID
+                                            td Your identity provider at sign-in
+                                        tr
+                                            td Authentication data
+                                            td Access tokens, session state, cached OIDC claims
+                                            td Generated during sign-in (no passwords)
+                                        tr
+                                            td Document content
+                                            td Documents you upload and the content of your open presentation
+                                            td Uploaded or opened by you
+                                        tr
+                                            td Conversation data
+                                            td Chat messages, retrieval queries, AI responses
+                                            td Generated as you use the Service
+                                        tr
+                                            td Usage data
+                                            td API calls, document uploads, query and token counts
+                                            td Collected automatically
+                                        tr
+                                            td Device &amp; technical data
+                                            td IP address, browser type, operating system
+                                            td Collected automatically
+                            p We do not collect your password &mdash; authentication is handled by your identity provider using OAuth 2.0 / OpenID Connect. You should not upload documents containing special categories of sensitive personal data unless you have a lawful basis and any required data-processing terms are in place.
+
+                        // 3
+                        .pp-section#use
+                            h2 3. How We Use Your Information
+                            p We use the data described above to:
+                            ul
+                                li provide, operate and maintain the Service, including generating, adapting and modifying presentations from your documents;
+                                li authenticate you and secure your account and sessions;
+                                li store and retrieve your uploaded documents and AI knowledge, scoped to your project;
+                                li respond to your requests and provide customer support;
+                                li monitor usage, detect and prevent fraud, abuse and security incidents, and enforce our Terms; and
+                                li meet our legal, regulatory and contractual obligations.
+                            p We do not use your document content or AI output for advertising, and we do not sell your personal data.
+
+                        // 4
+                        .pp-section#legal-basis
+                            h2 4. Legal Bases for Processing
+                            p Where data-protection law &mdash; such as the EU/UK General Data Protection Regulation (GDPR) or India&rsquo;s Digital Personal Data Protection Act, 2023 (DPDP Act) &mdash; applies, we rely on the following legal bases: performance of a contract (to provide the Service to you or your organisation); our legitimate interests (to secure, operate and improve the Service, balanced against your rights); compliance with a legal obligation; and consent, where specifically requested. Where Inscripta AI acts as a processor (or, under the DPDP Act, a Data Processor) it processes data on the documented instructions of your organisation as controller (Data Fiduciary).
+
+                        // 5
+                        .pp-section#storage
+                            h2 5. Storage, Location &amp; Security
+                            p Customer content and account data are hosted on cloud infrastructure operated by our infrastructure provider, #[strong E2E Networks], located in #[strong India]. We apply appropriate technical and organisational measures to protect your data, including:
+                            ul
+                                li encryption of data in transit using #[strong TLS 1.2 or higher], and encryption of data at rest;
+                                li authentication via OAuth 2.0 / OpenID Connect, with no password storage;
+                                li access scoped to members of the relevant project, so document content is not shared across organisations;
+                                li role-based access controls, secrets management, and audit logging of access to customer data; and
+                                li network and application security controls, vulnerability management and monitoring.
+                            .table-responsive.mt-3
+                                table.table.table-bordered.pp-table
+                                    thead
+                                        tr
+                                            th(scope='col') Store
+                                            th(scope='col') What it holds
+                                    tbody
+                                        tr
+                                            td Document database
+                                            td User identity, document metadata, AI conversation logs, usage metrics, audit events (with anonymised IP and hashed user-agent) and cached OIDC claims
+                                        tr
+                                            td Vector database
+                                            td Document text chunks and vector embeddings used for retrieval
+                                        tr
+                                            td In-memory store
+                                            td Hashed authentication state tokens, token blacklists and session data
+
+                        // 6
+                        .pp-section#retention
+                            h2 6. Data Retention &amp; Deletion
+                            p We retain data only for as long as needed to provide the Service and to meet our legal obligations. Retention by data type:
+                            .table-responsive
+                                table.table.table-bordered.pp-table
+                                    thead
+                                        tr
+                                            th(scope='col') Data type
+                                            th(scope='col') Storage
+                                            th(scope='col') Retention
+                                    tbody
+                                        tr
+                                            td Uploaded documents
+                                            td Stored securely, scoped to your project
+                                            td Until you delete them
+                                        tr
+                                            td Open presentation content
+                                            td Sent for processing during an operation
+                                            td Not stored after the operation completes
+                                        tr
+                                            td AI knowledge entries
+                                            td Stored per-user and per-project
+                                            td Until you delete them
+                                        tr
+                                            td Authentication tokens
+                                            td Stored in your browser&rsquo;s local storage
+                                            td Until session expiry or logout
+                                        tr
+                                            td Passwords
+                                            td Never stored by NorgAI
+                                            td &mdash;
+                            p You can delete your uploaded documents and AI knowledge at any time from within the Service. Following account termination, we delete or de-identify the associated customer data within #[strong 30 days], unless a longer period is required by law. Backup copies are purged on our standard backup-rotation cycle.
+
+                        // 7
+                        .pp-section#ai
+                            h2 7. AI Processing &amp; Model Training
+                            p NorgAI uses generative-AI and large language models, including models operated by third-party model providers engaged as sub-processors, to generate output from your documents. NorgAI&rsquo;s memory and knowledge features are designed to leverage your organisation&rsquo;s own institutional knowledge to improve output for you, within your own account and projects.
+                            .pp-note
+                                p #[strong We do not use your documents or AI output to train, fine-tune or improve foundation models for the benefit of other customers, and we do not share your documents or output with other customers.] We may use aggregated and de-identified information that does not identify you or any individual to operate, secure and improve the Service.
+                            p Output is generated automatically, may be inaccurate or incomplete, and should be reviewed before use. NorgAI proposes a plan for your review and approval before applying changes, and the Service does not make automated decisions producing legal or similarly significant effects about individuals.
+
+                        // 8
+                        .pp-section#sharing
+                            h2 8. Sharing &amp; Sub-processors
+                            p We do not sell, rent or trade your personal data or document content. We share data only as follows:
+                            ul
+                                li #[strong Sub-processors] who process data on our behalf to provide the Service &mdash; including our cloud-infrastructure provider and large-language-model providers &mdash; under contractual confidentiality and data-protection obligations;
+                                li #[strong within your organisation], with members of the relevant project;
+                                li #[strong where required by law], or to protect the rights, safety and security of users, the public or Inscripta AI; and
+                                li #[strong in connection with a corporate transaction] such as a merger, acquisition or sale of assets, subject to this Policy.
+                            p Where required, we enter into data-sharing agreements or data-processing addenda with sub-processors and with customers. A current list of sub-processors is available on request at #[a.text-primary(href='mailto:norgai.support@inscripta.ai') norgai.support@inscripta.ai].
+                            p NorgAI runs as an add-in inside Microsoft PowerPoint and is distributed through Microsoft AppSource. Your use of Microsoft PowerPoint, Microsoft 365 and Microsoft AppSource is governed by Microsoft&rsquo;s own terms and privacy statement, for which Inscripta AI is not responsible.
+
+                        // 9
+                        .pp-section#transfers
+                            h2 9. International Data Transfers
+                            p Your data is primarily stored and processed in India. Where data is transferred to, or accessed from, a country other than the one in which you are located &mdash; for example by a sub-processor &mdash; we put in place appropriate safeguards required by applicable data-protection law, such as standard contractual clauses, to protect your data.
+
+                        // 10
+                        .pp-section#rights
+                            h2 10. Your Privacy Rights
+                            p Subject to applicable law, you have the right to:
+                            ul
+                                li #[strong access] the personal data we hold about you;
+                                li #[strong correct or update] inaccurate or incomplete personal data;
+                                li #[strong delete] your personal data;
+                                li #[strong restrict or object to] our processing of your personal data;
+                                li #[strong data portability] &mdash; receive your data in a portable format; and
+                                li #[strong withdraw consent] at any time, where processing is based on consent.
+                            p To exercise these rights, contact us at #[a.text-primary(href='mailto:norgai.support@inscripta.ai') norgai.support@inscripta.ai]. We will respond within the timeframe required by applicable law. Where you use the Service under your organisation&rsquo;s subscription, you may need to direct certain requests to your organisation as the controller, and we will assist them in responding. You also have the right to lodge a complaint with your local data-protection authority.
+                            p #[strong Region-specific rights.] If you are in the EEA or UK, you have the rights described above under the GDPR. If you are in India, you may exercise your rights under the DPDP Act, including by contacting our Grievance Officer (see &ldquo;Contact Us&rdquo; below). If you are a California resident, you may have rights under the CCPA/CPRA, including the right to know, delete and correct your personal information, and the right not to be discriminated against for exercising those rights; we do not sell or share personal information as those terms are defined under the CCPA/CPRA.
+
+                        // 11
+                        .pp-section#children
+                            h2 11. Children&rsquo;s Privacy
+                            p The Service is intended for business use by individuals who are at least #[strong 18 years of age]. We do not knowingly collect personal data from children or minors. If you believe a minor has provided us with personal data, please contact us so we can delete it.
+
+                        // 12
+                        .pp-section#cookies
+                            h2 12. Cookies &amp; Local Storage
+                            p The NorgAI task-pane stores authentication tokens in your browser&rsquo;s local storage to keep you signed in; these persist until session expiry or logout. We and our analytics providers may use cookies and similar technologies to operate and improve the Service. For cookies used on our marketing website, see our #[a.text-primary(href='/legal/privacy') website Privacy Policy].
+
+                        // 13
+                        .pp-section#breach
+                            h2 13. Data Breach Notification
+                            p We maintain a documented security incident-response process. In the event of a personal-data breach that is likely to result in a risk to affected individuals, we will notify the relevant supervisory authority and affected individuals (or, where Inscripta AI is a processor, the controller) without undue delay and, where feasible, #[strong within 72 hours] of becoming aware of it, in accordance with applicable law.
+
+                        // 14
+                        .pp-section#changes
+                            h2 14. Changes to This Policy
+                            p We may update this Privacy Policy from time to time to reflect changes to the Service or to legal requirements. For material changes we will update the &ldquo;Last Updated&rdquo; date above and, where appropriate, provide additional notice. Your continued use of the Service after changes take effect constitutes acceptance of the revised Policy.
+
+                        // 15
+                        .pp-section#contact
+                            h2 15. Contact Us
+                            p For questions about this Privacy Policy, or to exercise your privacy rights, contact Inscripta AI Technologies Private Limited at:
+                            ul
+                                li Privacy &amp; support: #[a.text-primary(href='mailto:norgai.support@inscripta.ai') norgai.support@inscripta.ai]
+                                li General &amp; legal notices: #[a.text-primary(href='mailto:sales@inscripta.ai') sales@inscripta.ai]
+                            p #[strong Grievance Officer (India).] In accordance with India&rsquo;s Digital Personal Data Protection Act, 2023 and applicable IT rules, our Grievance Officer can be reached at #[a.text-primary(href='mailto:norgai.support@inscripta.ai') norgai.support@inscripta.ai]. We aim to acknowledge and address grievances within the timeframe prescribed by applicable law.
+
+                        .pp-cta
+                            a.btn.btn-secondary.mt-2(href='/legal/norgai-terms')
+                                i.fas.fa-arrow-left.me-2
+                                | Read the NorgAI Terms of Use
+
+        // Footer
+        include /pug/includes/footer_new.pug

--- a/src/pug/products/norgai.pug
+++ b/src/pug/products/norgai.pug
@@ -846,7 +846,7 @@ html(lang='en')
                     .mt-3
                         a.small.text-muted.mx-2(href='/legal/norgai-terms') NorgAI Terms of Use
                         span.small.text-muted &middot;
-                        a.small.text-muted.mx-2(href='/legal/privacy') Privacy Policy
+                        a.small.text-muted.mx-2(href='/legal/norgai-privacy') Privacy Policy
 
         // Footer
         include /pug/includes/footer_new.pug

--- a/src/pug/products/norgai/quick-start.pug
+++ b/src/pug/products/norgai/quick-start.pug
@@ -336,7 +336,7 @@ html(lang='en')
                                     tr
                                         td Privacy policy
                                         td
-                                            a.text-primary(href='/legal/privacy') inscripta.ai/legal/privacy
+                                            a.text-primary(href='/legal/norgai-privacy') inscripta.ai/legal/norgai-privacy
                                     tr
                                         td Terms of use
                                         td

--- a/src/pug/products/norgai/user-guide.pug
+++ b/src/pug/products/norgai/user-guide.pug
@@ -619,7 +619,7 @@ html(lang='en')
                                 li #[strong Authentication:] NorgAI uses OAuth 2.0 / OIDC via your organisation&rsquo;s identity provider and does not store passwords.
                                 li #[strong Data access:] Uploaded documents are accessible only to project members; no document content is shared across organisations.
                                 li #[strong AI model:] Content is processed by a large language model. See the Privacy Policy for data handling, retention and model-training policies.
-                            p Full privacy policy: #[a.text-primary(href='/legal/privacy') inscripta.ai/legal/privacy]
+                            p Full privacy policy: #[a.text-primary(href='/legal/norgai-privacy') inscripta.ai/legal/norgai-privacy]
 
                         // 17. Support & Contact
                         .ug-section#support
@@ -641,7 +641,7 @@ html(lang='en')
                                             td: a.text-primary(href='mailto:sales@inscripta.ai') sales@inscripta.ai
                                         tr
                                             td Privacy policy
-                                            td: a.text-primary(href='/legal/privacy') inscripta.ai/legal/privacy
+                                            td: a.text-primary(href='/legal/norgai-privacy') inscripta.ai/legal/norgai-privacy
                                         tr
                                             td Terms of use
                                             td: a.text-primary(href='/legal/norgai-terms') inscripta.ai/legal/norgai-terms


### PR DESCRIPTION
Create a dedicated privacy policy for the NorgAI PowerPoint add-in at /legal/norgai-privacy, covering data collected, storage location, retention, 30-day post-termination deletion, AI/no-model-training, sub-processors, GDPR/DPDP/CCPA rights, breach notification and a Grievance Officer, to match the Microsoft AppSource attestation answers.

Point the NorgAI product page, quick-start and user guide at the new policy (global site footer and the website privacy policy are left unchanged).